### PR TITLE
Skip alerts in disabled repos

### DIFF
--- a/main.go
+++ b/main.go
@@ -195,8 +195,10 @@ func getEnterpriseSecretScanningAlerts(ctx context.Context, client *github.Clien
 			return err
 		}
 		for _, alert := range alerts {
-			repoKey := RepoKey{Owner: alert.GetRepository().GetOwner().GetLogin(), Name: alert.GetRepository().GetName()}
-			output[repoKey] = append(output[repoKey], alert)
+			if !alert.GetRepository().GetDisabled() {
+				repoKey := RepoKey{Owner: alert.GetRepository().GetOwner().GetLogin(), Name: alert.GetRepository().GetName()}
+				output[repoKey] = append(output[repoKey], alert)
+			}
 		}
 		if resp.After == "" {
 			break

--- a/main.go
+++ b/main.go
@@ -195,16 +195,24 @@ func getEnterpriseSecretScanningAlerts(ctx context.Context, client *github.Clien
 			return err
 		}
 		for _, alert := range alerts {
-			if !alert.GetRepository().GetDisabled() {
-				repoKey := RepoKey{Owner: alert.GetRepository().GetOwner().GetLogin(), Name: alert.GetRepository().GetName()}
-				output[repoKey] = append(output[repoKey], alert)
-			}
+			repoKey := RepoKey{Owner: alert.GetRepository().GetOwner().GetLogin(), Name: alert.GetRepository().GetName()}
+			output[repoKey] = append(output[repoKey], alert)
 		}
 		if resp.After == "" {
 			break
 		}
 		opts.ListCursorOptions.After = resp.After
 	}
+
+	// Loop through all repos in the output and remove any that are disabled
+	for repoKey := range output {
+		_, resp, err := client.Repositories.Get(ctx, repoKey.Owner, repoKey.Name)
+		if err != nil && resp.StatusCode == 403 && strings.Contains(err.Error(), "Repository access blocked") {
+			log.Printf("Warning: repository %s/%s is disabled\n", repoKey.Owner, repoKey.Name)
+			delete(output, repoKey)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Disabled repositories on Enterprise Server return a 403 when retrieving repo information including secret scanning alert locations. This pull request skips processing of disabled repositories.